### PR TITLE
🔀 :: (#21) 디자인 시스템 NoticeItem 구현

### DIFF
--- a/GYMI-components/src/main/java/com/mpersand/gymi_components/component/item/GYMINoticeItem.kt
+++ b/GYMI-components/src/main/java/com/mpersand/gymi_components/component/item/GYMINoticeItem.kt
@@ -1,0 +1,53 @@
+package com.mpersand.gymi_components.component.item
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.mpersand.gymi_components.theme.GYMITheme
+
+@Composable
+fun GYMINoticeItem(
+    modifier: Modifier = Modifier,
+    title: String,
+    content: String,
+    date: String
+) {
+    Surface(
+        modifier = modifier,
+        color = GYMITheme.colors.n5,
+        shape = RoundedCornerShape(8.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(
+                    horizontal = 16.dp,
+                    vertical = 14.dp
+                )
+        ) {
+            Row {
+                Text(
+                    text = title,
+                    style = GYMITheme.typography.h5
+                )
+                Spacer(modifier = Modifier.weight(1f))
+                Text(
+                    text = date,
+                    style = GYMITheme.typography.body3
+                )
+            }
+            Spacer(modifier = Modifier.height(14.dp))
+            Text(
+                text = content,
+                style = GYMITheme.typography.subtitle4
+            )
+        }
+    }
+}

--- a/GYMI-components/src/main/java/com/mpersand/gymi_components/theme/GYMITypography.kt
+++ b/GYMI-components/src/main/java/com/mpersand/gymi_components/theme/GYMITypography.kt
@@ -45,6 +45,13 @@ object GYMITypography {
     )
 
     @Stable
+    val h5 = TextStyle(
+        fontFamily = scdFont,
+        fontSize = 14.sp,
+        fontWeight = FontWeight.Bold
+    )
+
+    @Stable
     val body1 = TextStyle(
         fontFamily = scdFont,
         fontSize = 16.sp,
@@ -90,6 +97,13 @@ object GYMITypography {
     val subtitle3 = TextStyle(
         fontFamily = scdFont,
         fontSize = 16.sp,
+        fontWeight = FontWeight.Medium
+    )
+
+    @Stable
+    val subtitle4 = TextStyle(
+        fontFamily = scdFont,
+        fontSize = 12.sp,
         fontWeight = FontWeight.Medium
     )
 }


### PR DESCRIPTION
### 개요
- 디자인 시스템에 맞게 NoticeItem 구현

### 작업내용
- NoticeItem에서 사용되는 Typography 추가
- GYMINoticeItem 구현

### 구현화면
<img width="340" alt="스크린샷 2023-08-01 오후 4 58 26" src="https://github.com/Team-Ampersand/GUS/assets/85855341/a4cc2005-e692-494d-a892-cd7ef3d596ff">