### PR TITLE
🔀 :: (#49) gymi notice item dark theme setting

### DIFF
--- a/GYMI-components/src/main/java/com/mpersand/gymi_components/component/item/GYMINoticeItem.kt
+++ b/GYMI-components/src/main/java/com/mpersand/gymi_components/component/item/GYMINoticeItem.kt
@@ -35,18 +35,21 @@ fun GYMINoticeItem(
             Row {
                 Text(
                     text = title,
-                    style = GYMITheme.typography.h5
+                    style = GYMITheme.typography.h5,
+                    color = GYMITheme.colors.bw
                 )
                 Spacer(modifier = Modifier.weight(1f))
                 Text(
                     text = date,
-                    style = GYMITheme.typography.body3
+                    style = GYMITheme.typography.body3,
+                    color = GYMITheme.colors.bw
                 )
             }
             Spacer(modifier = Modifier.height(14.dp))
             Text(
                 text = content,
-                style = GYMITheme.typography.subtitle4
+                style = GYMITheme.typography.subtitle4,
+                color = GYMITheme.colors.bw
             )
         }
     }

--- a/GYMI-components/src/main/java/com/mpersand/gymi_components/theme/GYMITheme.kt
+++ b/GYMI-components/src/main/java/com/mpersand/gymi_components/theme/GYMITheme.kt
@@ -1,5 +1,6 @@
 package com.mpersand.gymi_components.theme
 
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
@@ -59,7 +60,7 @@ private fun GYMIThemeLocalProvider(
 }
 
 private val Theme.colors: GYMIColor
-    get() = when(this) {
+    get() = when (this) {
         Theme.DARK -> GYMIDarkColors
         Theme.LIGHT -> GYMILightColors
     }
@@ -86,6 +87,8 @@ fun GYMITheme(
     typography: GYMITypography = GYMITheme.typography,
     content: @Composable () -> Unit
 ) {
+    GYMITheme.gymiTheme = if (isSystemInDarkTheme()) Theme.DARK else Theme.LIGHT
+
     GYMIThemeLocalProvider(
         colors = gymiTheme.colors,
         typography = typography,


### PR DESCRIPTION
### 개요
- GYMINoticeItem이 시스템 테마에 맞게 변경되도록 설정

### 작업내용
- GYMiNoticeItem text color 설정
- GYMITheme가 시스템 색상에 맞춰 변경되도록 설정